### PR TITLE
DEV: Resolve `link-to.positional-arguments` deprecation

### DIFF
--- a/javascripts/discourse/templates/components/custom-navigation.hbs
+++ b/javascripts/discourse/templates/components/custom-navigation.hbs
@@ -2,7 +2,10 @@
   <div class="category-sidebar">
     <ul class="category-sidebar-list">
       <li class="category-sidebar-list-item all-topics">
-        <LinkTo @route="discovery.latest" class="category-sidebar-list-item-link">
+        <LinkTo
+          @route="discovery.latest"
+          class="category-sidebar-list-item-link"
+        >
           All Topics
         </LinkTo>
       </li>
@@ -33,7 +36,7 @@
               @route="discovery.category"
               @model={{concat sidebarCategory.slug "/" sidebarCategory.id}}
               class="category-sidebar-list-item-link"
-              @current-when=(eq currentRouteCategoryId sidebarCategory.id)
+              @current-when={{eq currentRouteCategoryId sidebarCategory.id}}
             >
               <span
                 class="sidebar-category-badge"
@@ -62,15 +65,15 @@
                 >
                   <LinkTo
                     @route="discovery.category"
-                    @model=(concat
+                    @model={{concat
                       sidebarCategory.slug
                       "/"
                       childCategory.slug
                       "/"
                       childCategory.id
-                    )
+                    }}
                     class="category-sidebar-list-item-link subcategory-item"
-                    @current-when=(eq currentRouteCategoryId childCategory.id)
+                    @current-when={{eq currentRouteCategoryId childCategory.id}}
                   >
                     {{childCategory.name}}
                   </LinkTo>
@@ -96,7 +99,7 @@
                         >
                           <LinkTo
                             @route="discovery.category"
-                            @model=(concat
+                            @model={{concat
                               sidebarCategory.slug
                               "/"
                               childCategory.slug
@@ -104,11 +107,12 @@
                               grandChildCategory.slug
                               "/"
                               grandChildCategory.id
-                            )
+                            }}
                             class="category-sidebar-list-item-link subcategory-item grandchild"
-                            @current-when=(eq
-                              currentRouteCategoryId grandChildCategory.id
-                            )
+                            @current-when={{eq
+                              currentRouteCategoryId
+                              grandChildCategory.id
+                            }}
                           >
                             {{grandChildCategory.name}}
                           </LinkTo>

--- a/javascripts/discourse/templates/components/custom-navigation.hbs
+++ b/javascripts/discourse/templates/components/custom-navigation.hbs
@@ -31,7 +31,7 @@
           <div class="category-sidebar-list-item__parent-container">
             <LinkTo
               @route="discovery.category"
-              @model=(concat sidebarCategory.slug "/" sidebarCategory.id)
+              @model={{concat sidebarCategory.slug "/" sidebarCategory.id}}
               class="category-sidebar-list-item-link"
               @current-when=(eq currentRouteCategoryId sidebarCategory.id)
             >

--- a/javascripts/discourse/templates/components/custom-navigation.hbs
+++ b/javascripts/discourse/templates/components/custom-navigation.hbs
@@ -2,9 +2,9 @@
   <div class="category-sidebar">
     <ul class="category-sidebar-list">
       <li class="category-sidebar-list-item all-topics">
-        {{#link-to "discovery.latest" class="category-sidebar-list-item-link"}}
+        <LinkTo @route="discovery.latest" class="category-sidebar-list-item-link">
           All Topics
-        {{/link-to}}
+        </LinkTo>
       </li>
 
       {{#each sidebarCategories as |sidebarCategory|}}
@@ -29,16 +29,16 @@
           }}
         >
           <div class="category-sidebar-list-item__parent-container">
-            {{#link-to
-              "discovery.category"
-              (concat sidebarCategory.slug "/" sidebarCategory.id)
+            <LinkTo
+              @route="discovery.category"
+              @model=(concat sidebarCategory.slug "/" sidebarCategory.id)
               class="category-sidebar-list-item-link"
-              current-when=(eq currentRouteCategoryId sidebarCategory.id)
-            }}
+              @current-when=(eq currentRouteCategoryId sidebarCategory.id)
+            >
               <span
                 class="sidebar-category-badge"
               ></span>{{sidebarCategory.name}}
-            {{/link-to}}
+            </LinkTo>
             {{#if sidebarCategory.has_children}}
               <div class="sidebar-category-toggle">
                 {{d-icon "chevron-right"}}
@@ -60,9 +60,9 @@
                     (concat "--category-color: #" childCategory.color ";")
                   }}
                 >
-                  {{#link-to
-                    "discovery.category"
-                    (concat
+                  <LinkTo
+                    @route="discovery.category"
+                    @model=(concat
                       sidebarCategory.slug
                       "/"
                       childCategory.slug
@@ -70,10 +70,10 @@
                       childCategory.id
                     )
                     class="category-sidebar-list-item-link subcategory-item"
-                    current-when=(eq currentRouteCategoryId childCategory.id)
-                  }}
+                    @current-when=(eq currentRouteCategoryId childCategory.id)
+                  >
                     {{childCategory.name}}
-                  {{/link-to}}
+                  </LinkTo>
 
                   {{#if
                     (or
@@ -94,9 +94,9 @@
                             )
                           }}
                         >
-                          {{#link-to
-                            "discovery.category"
-                            (concat
+                          <LinkTo
+                            @route="discovery.category"
+                            @model=(concat
                               sidebarCategory.slug
                               "/"
                               childCategory.slug
@@ -106,12 +106,12 @@
                               grandChildCategory.id
                             )
                             class="category-sidebar-list-item-link subcategory-item grandchild"
-                            current-when=(eq
+                            @current-when=(eq
                               currentRouteCategoryId grandChildCategory.id
                             )
-                          }}
+                          >
                             {{grandChildCategory.name}}
-                          {{/link-to}}
+                          </LinkTo>
                         </li>
                       {{/each}}
                     </ul>


### PR DESCRIPTION
https://deprecations.emberjs.com/v3.x#toc_ember-glimmer-link-to-positional-arguments

This deprecation happens at build-time, which means it doesn't get surfaced like other deprecations in Discourse themes/plugins.