### PR TITLE
A11Y: update sidebar nav to be keyboard navigable

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -81,9 +81,7 @@
           }
         }
         .subcategories {
-          transition:
-            height 0.2s ease-in-out,
-            opacity 1s ease-in-out;
+          transition: height 0.2s ease-in-out, opacity 1s ease-in-out;
           height: 0px;
           opacity: 0;
           overflow: hidden;

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -81,7 +81,9 @@
           }
         }
         .subcategories {
-          transition: height 0.2s ease-in-out, opacity 1s ease-in-out;
+          transition:
+            height 0.2s ease-in-out,
+            opacity 1s ease-in-out;
           height: 0px;
           opacity: 0;
           overflow: hidden;
@@ -140,23 +142,15 @@
         height: 100%;
         padding: 0 0 0 0.5em;
         transition: all 0.25s;
-        &:hover,
-        &:focus {
+        &:hover {
           color: var(--primary);
-        }
-      }
-
-      a:hover,
-      a:focus {
-        + .sidebar-category-toggle {
-          color: var(--primary-low-mid) !important;
         }
       }
     }
 
-    &:hover {
-      cursor: pointer;
-      .sidebar-category-toggle {
+    .sidebar-category-toggle {
+      &:hover {
+        cursor: pointer;
         color: var(--primary);
       }
     }
@@ -177,12 +171,6 @@
 
   a {
     padding: 0 0 0.75em 0;
-  }
-}
-
-.category-sidebar-list-item__parent:has(.subcategories:hover) {
-  .sidebar-category-toggle {
-    color: var(--primary-low-mid);
   }
 }
 

--- a/javascripts/discourse/components/custom-navigation.js
+++ b/javascripts/discourse/components/custom-navigation.js
@@ -28,22 +28,34 @@ export default Component.extend({
 
   @action
   toggleSection(e) {
-    if (e.target.nodeName !== "A" && (e.type === "click" || (e.type === "keydown" && e.key === "Enter"))) {
-        const currentParent = e.target.closest(".category-sidebar-list-item__parent");
-        const toggle = currentParent.querySelector(".sidebar-category-toggle");
+    if (
+      e.target.nodeName !== "A" &&
+      (e.type === "click" || (e.type === "keydown" && e.key === "Enter"))
+    ) {
+      const currentParent = e.target.closest(
+        ".category-sidebar-list-item__parent"
+      );
+      const toggle = currentParent.querySelector(".sidebar-category-toggle");
 
-        currentParent.classList.toggle("show-children");
-        toggle.setAttribute('aria-expanded', toggle.getAttribute('aria-expanded') === 'false');
+      currentParent.classList.toggle("show-children");
+      toggle.setAttribute(
+        "aria-expanded",
+        toggle.getAttribute("aria-expanded") === "false"
+      );
 
-        if (settings.accordion_expansion) {
-          // toggle state of all shown items
-            document.querySelectorAll(".category-sidebar-list-item__parent.show-children").forEach((item) => {
-                if (item !== currentParent) {
-                    item.classList.remove("show-children");
-                    item.querySelector(".sidebar-category-toggle").setAttribute("aria-expanded", 'false');
-                }
-            });
-        }
+      if (settings.accordion_expansion) {
+        // toggle state of all shown items
+        document
+          .querySelectorAll(".category-sidebar-list-item__parent.show-children")
+          .forEach((item) => {
+            if (item !== currentParent) {
+              item.classList.remove("show-children");
+              item
+                .querySelector(".sidebar-category-toggle")
+                .setAttribute("aria-expanded", "false");
+            }
+          });
+      }
     }
-},
+  },
 });

--- a/javascripts/discourse/components/custom-navigation.js
+++ b/javascripts/discourse/components/custom-navigation.js
@@ -28,21 +28,22 @@ export default Component.extend({
 
   @action
   toggleSection(e) {
-    if (e.target.nodeName !== "A") {
-      let closest = e.target.closest(".category-sidebar-list-item__parent");
-      closest.classList.toggle("show-children");
+    if (e.target.nodeName !== "A" && (e.type === "click" || (e.type === "keydown" && e.key === "Enter"))) {
+        const currentParent = e.target.closest(".category-sidebar-list-item__parent");
+        const toggle = currentParent.querySelector(".sidebar-category-toggle");
 
-      if (settings.accordion_expansion) {
-        const expandedItems = document.querySelectorAll(
-          ".category-sidebar-list-item__parent"
-        );
+        currentParent.classList.toggle("show-children");
+        toggle.setAttribute('aria-expanded', toggle.getAttribute('aria-expanded') === 'false');
 
-        expandedItems.forEach((item) => {
-          if (item !== closest) {
-            item.classList.remove("show-children");
-          }
-        });
-      }
+        if (settings.accordion_expansion) {
+          // toggle state of all shown items
+            document.querySelectorAll(".category-sidebar-list-item__parent.show-children").forEach((item) => {
+                if (item !== currentParent) {
+                    item.classList.remove("show-children");
+                    item.querySelector(".sidebar-category-toggle").setAttribute("aria-expanded", 'false');
+                }
+            });
+        }
     }
-  },
+},
 });

--- a/javascripts/discourse/templates/components/custom-navigation.hbs
+++ b/javascripts/discourse/templates/components/custom-navigation.hbs
@@ -12,8 +12,6 @@
 
       {{#each sidebarCategories as |sidebarCategory|}}
         <li
-          role="button"
-          {{on "click" toggleSection}}
           class={{concat
             "category-sidebar-list-item category-sidebar-list-item__parent "
             (if
@@ -43,7 +41,28 @@
               ></span>{{sidebarCategory.name}}
             </LinkTo>
             {{#if sidebarCategory.has_children}}
-              <div class="sidebar-category-toggle">
+              <div
+                class="sidebar-category-toggle"
+                role="button"
+                tabindex="0"
+                {{on "click" toggleSection}}
+                {{on "keydown" toggleSection}}
+                aria-expanded={{if
+                  (or
+                    (and
+                      (eq currentRouteCategoryId sidebarCategory.id)
+                      sidebarCategory.has_children
+                    )
+                    (child-is-active currentRouteCategoryId sidebarCategory.id)
+                  )
+                  "true"
+                  "false"
+                }}
+                aria-controls={{concat
+                  "category-sidebar-list-"
+                  sidebarCategory.id
+                }}
+              >
                 {{d-icon "chevron-right"}}
               </div>
             {{/if}}
@@ -54,7 +73,10 @@
               (child-is-active currentRouteCategoryId sidebarCategory.id)
             )
           }}
-            <ul class="category-sidebar-list subcategories">
+            <ul
+              class="category-sidebar-list subcategories"
+              id="{{concat 'category-sidebar-list-' sidebarCategory.id}}"
+            >
               {{#each sidebarCategory.subcategories as |childCategory|}}
                 <li
                   class="category-sidebar-list-item child

--- a/javascripts/discourse/templates/components/custom-navigation.hbs
+++ b/javascripts/discourse/templates/components/custom-navigation.hbs
@@ -46,7 +46,7 @@
                 role="button"
                 tabindex="0"
                 {{on "click" toggleSection}}
-                {{on "keydown" toggleSection}}
+                {{on "keyup" toggleSection}}
                 aria-expanded={{if
                   (or
                     (and
@@ -75,7 +75,7 @@
           }}
             <ul
               class="category-sidebar-list subcategories"
-              id="{{concat 'category-sidebar-list-' sidebarCategory.id}}"
+              id={{concat "category-sidebar-list-" sidebarCategory.id}}
             >
               {{#each sidebarCategory.subcategories as |childCategory|}}
                 <li


### PR DESCRIPTION
This accomplishes a few things related to a customer accessibility audit:

* Removes nested interactive elements (the parent links were nested within the toggle, now they're siblings) 
* Makes the menu keyboard navigable with tab and enter to toggle open/closed
* Includes `aria-expanded` and `aria-controls` so it's clear what the toggles are associated with 

I've had to adjust some corresponding styles, but these are minor. 