### PR TITLE
FIX: use keyup, not keydown

### DIFF
--- a/javascripts/discourse/components/custom-navigation.js
+++ b/javascripts/discourse/components/custom-navigation.js
@@ -30,7 +30,7 @@ export default Component.extend({
   toggleSection(e) {
     if (
       e.target.nodeName !== "A" &&
-      (e.type === "click" || (e.type === "keydown" && e.key === "Enter"))
+      (e.type === "click" || (e.type === "keyup" && e.key === "Enter"))
     ) {
       const currentParent = e.target.closest(
         ".category-sidebar-list-item__parent"


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse-sidebar-category-nav/pull/27, the template linter told me to use keyup instead of keydown and I forgot to change it here to match. 