### PR TITLE
A11Y: include accessible name for subcategory toggles

### DIFF
--- a/javascripts/discourse/templates/components/custom-navigation.hbs
+++ b/javascripts/discourse/templates/components/custom-navigation.hbs
@@ -62,6 +62,7 @@
                   "category-sidebar-list-"
                   sidebarCategory.id
                 }}
+                aria-label={{i18n (theme-prefix "subcategory_toggle") category=sidebarCategory.name}}
               >
                 {{d-icon "chevron-right"}}
               </div>

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,3 +1,4 @@
 en:
   theme_metadata:
     description: ""
+  subcategory_toggle: "%{category} subcategories" 


### PR DESCRIPTION
This adds an accessible name for the subcategory list toggle, which will read "%{category.name} subcategories" — currently these have no accessible descriptor because the buttons only contain an icon. 