### PR TITLE
Fix: Layout and subcategory toggle regression

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -4,21 +4,17 @@
     grid-template-columns: 20% 80%;
     grid-column-gap: 1em;
     grid-row-gap: 3px;
-    grid-template-areas: "sidebar navigation" "sidebar content";
-    grid-template-rows: 65px 1fr;
-
     @media screen and (max-width: 960px) {
       grid-template-columns: 25% 75%;
     }
-
     @media screen and (max-width: 720px) {
       grid-template-columns: 1fr;
-
       .category-sidebar-outlet {
         display: none;
       }
     }
-
+    grid-template-areas: "sidebar navigation" "sidebar content";
+    grid-template-rows: 65px 1fr;
     .category-sidebar-outlet,
     .list-controls + .loading-container + span,
     .dismiss-container-top + span {
@@ -33,7 +29,6 @@
       grid-area: content;
     }
   }
-
   #main-container + .container,
   #main-container + .reviewable,
   #main-container + .discourse-post-event-upcoming-events,
@@ -56,95 +51,80 @@
     border: 1px solid var(--secondary-very-high);
     display: block;
     visibility: visible;
-
     &:empty {
       border: none;
     }
-
     &::-webkit-scrollbar-thumb {
       background-color: var(--primary-low);
       border-radius: 8px;
       border: 4px solid var(--secondary);
     }
-
     &::-webkit-scrollbar {
       width: 16px;
     }
   }
-
-  .category-sidebar-list {
-    margin: 0;
-    list-style: none;
-
-    &.show-children {
-      .sidebar-category-toggle .d-icon {
-        transform: rotate(90deg);
-      }
-
-      .subcategories {
-        margin: 0.75em 0 0 0;
-        height: auto;
-        opacity: 1;
-        visibility: visible;
-
-        &:empty {
-          display: none !important;
-          visibility: hidden !important;
-        }
-      }
-    }
-
-    .subcategories {
-      transition:
-        height 0.2s ease-in-out,
-        opacity 1s ease-in-out;
-      height: 0;
-      opacity: 0;
-      overflow: hidden;
-      visibility: hidden;
-    }
-
-    &:not(.child, .grandchild) {
-      padding: 5px 5px 0 5px;
-
-      a {
-        border-radius: 4px;
-
-        &:hover,
-        &.active {
-          background-color: var(--secondary-very-high);
-        }
-      }
-    }
-
-    &.child {
-      padding: 0;
+  .category-sidebar {
+    &-list {
       margin: 0;
+      list-style: none;
+      &-item {
+        &.show-children {
+          .subcategories {
+            margin: 0.75em 0 0 0;
+            height: auto;
+            opacity: 1;
+            visibility: visible;
+            &:empty {
+              display: none !important;
+              visibility: hidden !important;
+            }
+          }
+        }
+        .subcategories {
+          transition: height 0.2s ease-in-out, opacity 1s ease-in-out;
+          height: 0px;
+          opacity: 0;
+          overflow: hidden;
+          visibility: hidden;
+        }
+        &:not(.child):not(.grandchild) {
+          padding: 5px 5px 0 5px;
+          a {
+            border-radius: 4px;
+            &:hover,
+            &.active {
+              background-color: var(--secondary-very-high);
+            }
+          }
+        }
+        &.child {
+          padding: 0;
+          margin: 0;
+        }
+        &-link {
+          display: flex;
+          align-items: center;
+          color: var(--primary-high);
+          text-transform: capitalize;
+          &:visited {
+            color: var(--primary-high);
+          }
+          .sidebar-category-badge {
+            width: 0.5em;
+            height: 0.5em;
+            border-radius: 2px;
+            margin-right: 0.5em;
+          }
+          &:hover,
+          &.active {
+            color: var(--primary-high);
+          }
+        }
+      }
     }
+  }
 
-    &-link {
-      display: flex;
-      align-items: center;
-      color: var(--primary-high);
-      text-transform: capitalize;
-
-      &:visited {
-        color: var(--primary-high);
-      }
-
-      .sidebar-category-badge {
-        width: 0.5em;
-        height: 0.5em;
-        border-radius: 2px;
-        margin-right: 0.5em;
-      }
-
-      &:hover,
-      &.active {
-        color: var(--primary-high);
-      }
-    }
-
+  .category-sidebar-list-item {
     .sidebar-category-badge {
       background-color: var(--category-color);
     }
@@ -153,7 +133,6 @@
       display: flex;
       align-items: baseline;
       width: 100%;
-
       .sidebar-category-toggle {
         cursor: pointer;
         margin-left: auto;
@@ -161,7 +140,6 @@
         height: 100%;
         padding: 0 0 0 0.5em;
         transition: all 0.25s;
-
         &:hover {
           color: var(--primary);
         }
@@ -174,12 +152,17 @@
         color: var(--primary);
       }
     }
+
+    &.show-children {
+      .sidebar-category-toggle .d-icon {
+        transform: rotate(90deg);
+      }
+    }
   }
 }
 
 .category-sidebar-list.subcategories {
   position: absolute;
-
   .show-children & {
     position: relative;
   }

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -4,17 +4,21 @@
     grid-template-columns: 20% 80%;
     grid-column-gap: 1em;
     grid-row-gap: 3px;
+
     @media screen and (max-width: 960px) {
       grid-template-columns: 25% 75%;
     }
+
     @media screen and (max-width: 720px) {
       grid-template-columns: 1fr;
+
       .category-sidebar-outlet {
         display: none;
       }
     }
     grid-template-areas: "sidebar navigation" "sidebar content";
     grid-template-rows: 65px 1fr;
+
     .category-sidebar-outlet,
     .list-controls + .loading-container + span,
     .dismiss-container-top + span {
@@ -29,6 +33,7 @@
       grid-area: content;
     }
   }
+
   #main-container + .container,
   #main-container + .reviewable,
   #main-container + .discourse-post-event-upcoming-events,
@@ -51,76 +56,26 @@
     border: 1px solid var(--secondary-very-high);
     display: block;
     visibility: visible;
+
     &:empty {
       border: none;
     }
+
     &::-webkit-scrollbar-thumb {
       background-color: var(--primary-low);
       border-radius: 8px;
       border: 4px solid var(--secondary);
     }
+
     &::-webkit-scrollbar {
       width: 16px;
     }
   }
+
   .category-sidebar {
     &-list {
       margin: 0;
       list-style: none;
-      &-item {
-        &.show-children {
-          .subcategories {
-            margin: 0.75em 0 0 0;
-            height: auto;
-            opacity: 1;
-            visibility: visible;
-            &:empty {
-              display: none !important;
-              visibility: hidden !important;
-            }
-          }
-        }
-        .subcategories {
-          transition: height 0.2s ease-in-out, opacity 1s ease-in-out;
-          height: 0px;
-          opacity: 0;
-          overflow: hidden;
-          visibility: hidden;
-        }
-        &:not(.child):not(.grandchild) {
-          padding: 5px 5px 0 5px;
-          a {
-            border-radius: 4px;
-            &:hover,
-            &.active {
-              background-color: var(--secondary-very-high);
-            }
-          }
-        }
-        &.child {
-          padding: 0;
-          margin: 0;
-        }
-        &-link {
-          display: flex;
-          align-items: center;
-          color: var(--primary-high);
-          text-transform: capitalize;
-          &:visited {
-            color: var(--primary-high);
-          }
-          .sidebar-category-badge {
-            width: 0.5em;
-            height: 0.5em;
-            border-radius: 2px;
-            margin-right: 0.5em;
-          }
-          &:hover,
-          &.active {
-            color: var(--primary-high);
-          }
-        }
-      }
     }
   }
 
@@ -129,10 +84,80 @@
       background-color: var(--category-color);
     }
 
+    &.show-children {
+      .subcategories {
+        margin: 0.75em 0 0 0;
+        height: auto;
+        opacity: 1;
+        visibility: visible;
+
+        &:empty {
+          display: none !important;
+          visibility: hidden !important;
+        }
+      }
+
+      .sidebar-category-toggle .d-icon {
+        transform: rotate(90deg);
+      }
+    }
+
+    .subcategories {
+      transition:
+        height 0.2s ease-in-out,
+        opacity 1s ease-in-out;
+      height: 0;
+      opacity: 0;
+      overflow: hidden;
+      visibility: hidden;
+    }
+
+    &:not(.child, .grandchild) {
+      padding: 5px 5px 0 5px;
+
+      a {
+        border-radius: 4px;
+
+        &:hover,
+        &.active {
+          background-color: var(--secondary-very-high);
+        }
+      }
+    }
+
+    &.child {
+      padding: 0;
+      margin: 0;
+    }
+
+    &-link {
+      display: flex;
+      align-items: center;
+      color: var(--primary-high);
+      text-transform: capitalize;
+
+      &:visited {
+        color: var(--primary-high);
+      }
+
+      .sidebar-category-badge {
+        width: 0.5em;
+        height: 0.5em;
+        border-radius: 2px;
+        margin-right: 0.5em;
+      }
+
+      &:hover,
+      &.active {
+        color: var(--primary-high);
+      }
+    }
+
     &__parent-container {
       display: flex;
       align-items: baseline;
       width: 100%;
+
       .sidebar-category-toggle {
         cursor: pointer;
         margin-left: auto;
@@ -140,6 +165,7 @@
         height: 100%;
         padding: 0 0 0 0.5em;
         transition: all 0.25s;
+
         &:hover {
           color: var(--primary);
         }
@@ -152,17 +178,12 @@
         color: var(--primary);
       }
     }
-
-    &.show-children {
-      .sidebar-category-toggle .d-icon {
-        transform: rotate(90deg);
-      }
-    }
   }
 }
 
 .category-sidebar-list.subcategories {
   position: absolute;
+
   .show-children & {
     position: relative;
   }

--- a/spec/system/sub_category_toggle_spec.rb
+++ b/spec/system/sub_category_toggle_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "My Theme Component", type: :system do
+describe "Sub Category Toggle", type: :system do
   let(:theme) do
     parent_theme = Fabricate(:theme, name: "Parent Theme")
     component = Fabricate(:theme, name: "Category Sidebar Navigation", component: true)

--- a/spec/system/sub_category_toggle_spec.rb
+++ b/spec/system/sub_category_toggle_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 describe "My Theme Component", type: :system do
-  let(:theme) {
+  let(:theme) do
     parent_theme = Fabricate(:theme, name: "Parent Theme")
     component = Fabricate(:theme, name: "Category Sidebar Navigation", component: true)
     parent_theme.set_default!
-  }
+  end
 
   before do
     theme
@@ -20,12 +20,18 @@ describe "My Theme Component", type: :system do
     expect(page).to have_no_selector(".category-sidebar-list-item__parent.show-children")
     find(".sidebar-category-toggle").click
     expect(page).to have_selector(".category-sidebar-list-item__parent.show-children")
-    expect(page).to have_selector(".category-sidebar-list-item-link.subcategory-item", text: @subcategory.name)
+    expect(page).to have_selector(
+      ".category-sidebar-list-item-link.subcategory-item",
+      text: @subcategory.name,
+    )
   end
 
   it "displays subcategories when on category page" do
     visit("/c/#{@category.id}")
     expect(page).to have_selector(".category-sidebar-list-item__parent.show-children")
-    expect(page).to have_selector(".category-sidebar-list-item-link.subcategory-item", text: @subcategory.name)
+    expect(page).to have_selector(
+      ".category-sidebar-list-item-link.subcategory-item",
+      text: @subcategory.name,
+    )
   end
 end

--- a/spec/system/sub_category_toggle_spec.rb
+++ b/spec/system/sub_category_toggle_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+describe "My Theme Component", type: :system do
+  let(:theme) {
+    parent_theme = Fabricate(:theme, name: "Parent Theme")
+    component = Fabricate(:theme, name: "Category Sidebar Navigation", component: true)
+    parent_theme.set_default!
+  }
+
+  before do
+    theme
+    upload_theme_component
+    @category = Fabricate(:category, name: "Test Category")
+    @subcategory = Fabricate(:category, name: "Test Subcategory", parent_category: @category)
+  end
+
+  it "displays subcategories when toggle is clicked" do
+    visit("/")
+
+    expect(page).to have_no_selector(".category-sidebar-list-item__parent.show-children")
+    find(".sidebar-category-toggle").click
+    expect(page).to have_selector(".category-sidebar-list-item__parent.show-children")
+    expect(page).to have_selector(".category-sidebar-list-item-link.subcategory-item", text: @subcategory.name)
+  end
+
+  it "displays subcategories when on category page" do
+    visit("/c/#{@category.id}")
+    expect(page).to have_selector(".category-sidebar-list-item__parent.show-children")
+    expect(page).to have_selector(".category-sidebar-list-item-link.subcategory-item", text: @subcategory.name)
+  end
+end


### PR DESCRIPTION
This PR fixes a regression that affected layout styles and caused the toggle to stop displaying subcategories. It looks like the regression may have come the stylelint updates from this [commit](https://github.com/discourse/discourse-sidebar-category-nav/commit/c7306aa4351cbaf60ea1e00df63413508ddca639#diff-10af73ea5a6485f8aeb8f16644ce91acfb63de060ba3c21ec70fa7d01babe700).

## Before
<img width="243" alt="Screenshot 2025-04-08 at 4 59 53 PM" src="https://github.com/user-attachments/assets/0e5b29a4-0a20-4c52-b63b-f5b6c2ac7d2b" />

## After
<img width="243" alt="Screenshot 2025-04-09 at 8 07 02 AM" src="https://github.com/user-attachments/assets/7d7cb0bf-05a7-4060-9ec4-bb7e9a91b93a" />
