### PR TITLE
DEV: add tests to ensure sidebar renders on correct routes

### DIFF
--- a/spec/system/navigation_rendering_spec.rb
+++ b/spec/system/navigation_rendering_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+describe "Navigation Rendering", type: :system do
+  let(:theme) do
+    parent_theme = Fabricate(:theme, name: "Parent Theme")
+    component = Fabricate(:theme, name: "Category Sidebar Navigation", component: true)
+    parent_theme.set_default!
+  end
+
+  before do
+    theme
+    upload_theme_component
+    @category = Fabricate(:category, name: "Test Category")
+    @topic = Fabricate(:topic, category: @category)
+    @post = Fabricate(:post, topic: @topic)
+  end
+
+  context "on discovery routes" do
+    it "renders navigation only once" do
+      visit("/")
+
+      expect(page).to have_selector(".category-sidebar-outlet", count: 1)
+    end
+
+    it "renders navigation on category pages" do
+      visit("/c/#{@category.id}")
+
+      expect(page).to have_selector(".category-sidebar-outlet", count: 1)
+    end
+  end
+
+  context "on topic routes" do
+    it "does not render navigation" do
+      visit("/t/#{@topic.slug}/#{@topic.id}")
+
+      expect(page).to have_no_selector(".category-sidebar-outlet")
+    end
+  end
+
+  context "on categories page" do
+    it "renders navigation only once" do
+      visit("/categories")
+
+      expect(page).to have_selector(".category-sidebar-outlet", count: 1)
+    end
+  end
+
+  context "navigation not rendered elsewhere" do
+    it "does not render on user profiles" do
+      user = Fabricate(:user)
+      visit("/u/#{user.username}")
+
+      expect(page).to have_no_selector(".category-sidebar-outlet")
+    end
+  end
+end


### PR DESCRIPTION
Caused a regression earlier (already fixed in 31013a184f5d596f4a0dcb4bcde5753fb55c0924) that caused this component to not render on all the correct routes. This adds some tests to avoid that happening again. 